### PR TITLE
update backports to fix breakage with latest ruby 2.0.0 patch level

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
       amq-client (~> 1.0.2)
       amq-protocol (>= 1.3.0)
       eventmachine
-    backports (3.3.3)
+    backports (3.6.4)
     daemons (1.1.9)
     eventmachine (1.0.3)
     haml (4.0.3)


### PR DESCRIPTION
The demo crashes when deployed (the demo URL is also down) - Heroku is now on patch level 645 - updating backports resolves this breakage.
